### PR TITLE
Add reference for Smalltalk cascades

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The cascading operator gives us the benefits of a fluent interface without the c
 The following languages implement the operator with the same general semantics as this proposal.
 
 * Dart — [Cascade notation](https://www.dartlang.org/guides/language/language-tour#cascade-notation-)
-* Smalltalk — message cascades
+* Smalltalk — [message cascades](https://en.wikipedia.org/wiki/Method_cascading#Smalltalk)
 
 ## References
 * [original dart proposal](https://docs.google.com/document/d/1U0PeHtVQHMQ8usy7xI5Luo01W5LuWR1acN5odgu_Mtw/edit?pli=1#heading=h.tkyl552ayct9)


### PR DESCRIPTION
The [Smalltalk documentation on gnu.org](http://www.gnu.org/software/smalltalk/manual/gst.html) is a bit verbose to link to, so [this Wikipedia section](https://en.wikipedia.org/wiki/Method_cascading#Smalltalk) might suffice. Feel free to suggest a better reference if you see one.